### PR TITLE
Fix MacOS Compatibility with MPS Kernel Fallback and Update Dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,13 @@
 import os
+
+if os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK") is None:
+    os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
 from accelerate import Accelerator
 from accelerate.logging import get_logger
 from accelerate.utils import (
-    InitProcessGroupKwargs, 
-    ProjectConfiguration, 
+    InitProcessGroupKwargs,
+    ProjectConfiguration,
     set_seed
 )
 import torch

--- a/src/da2/utils/io.py
+++ b/src/da2/utils/io.py
@@ -24,8 +24,11 @@ def read_mask(mask_path, shape):
     return mask
 
 def tensorize(array, model_dtype, device):
-    array = torch.from_numpy(array).to(device).to(model_dtype).unsqueeze(dim=0)
-    return array
+    tensor = torch.from_numpy(array)
+    if tensor.dtype != model_dtype:
+        tensor = tensor.to(model_dtype)
+    tensor = tensor.to(device)
+    return tensor.unsqueeze(dim=0)
 
 def load_infer_data(config, device):
     image_dir = config['inference']['images']

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "torch==2.5.0",
     "torchvision==0.20.0",
     "torchaudio==2.5.0",
-    "xformers==0.0.28.post2",
     "diffusers==0.32.0",
     "tensorboard==2.18.0",
     "utils3d @ git+https://github.com/EasternJournalist/utils3d.git@3913c65d81e05e47b9f367250cf8c0f7462a0900",
@@ -28,7 +27,8 @@ dependencies = [
     "timm==1.0.15",
     "trimesh==4.5.2",
     "transformers==4.46.3",
-    "matplotlib==3.9.2"
+    "matplotlib==3.9.2",
+    "xformers==0.0.28.post2; platform_system != 'Darwin'"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## PR Description:

**PR Overview:**

* Ensure Mac users don’t encounter unimplemented MPS kernels by enabling the CPU fallback before importing Torch in `app.py` (lines 1-14).
* Maintain compatibility with MPS by casting NumPy arrays to the model’s dtype before transferring them (in `src/da2/utils/io.py` lines 26-31).
* Restore `xformers` as a dependency while skipping it automatically on macOS using an environment marker (in `src/pyproject.toml`, lines 12-31).
* **Important Update**: If running on macOS, manually add `"mps"` to the list of devices in the `Accelerator` class at line 482 in the `accelerate/accelerator.py` file. Modify the following line:

  ```python
  if self.device.type not in ("xpu", "cuda", "npu", "xla", "mlu", "musa") or is_torch_xla_available(check_is_tpu=True):
  ```

  To include `"mps"`:

  ```python
  if self.device.type not in ("xpu", "cuda", "npu", "xla", "mlu", "musa", "mps") or is_torch_xla_available(check_is_tpu=True):
  ```

**Validation Results:**

* Ran `pip install -e .` (or reinstalled the package) on macOS to confirm that `xformers` is properly skipped.
* Executed `python app.py` and ran a sample to ensure the UI works without any MPS errors.


```bash
((.venv) ) syun@syunnoMacBook-Pro DA-2 % python app.py                                                                           

xFormers not available
xFormers not available
xFormers not available
* Running on local URL:  http://0.0.0.0:6381
* To create a public link, set `share=True` in `launch()`.
/Users/syun/python_project/DAv2/syun/.venv/lib/python3.12/site-packages/torch/amp/grad_scaler.py:132: UserWarning: torch.cuda.amp.GradScaler is enabled, but CUDA is not available.  Disabling.
  warnings.warn(
/Users/syun/python_project/DAv2/syun/.venv/lib/python3.12/site-packages/torch/nn/functional.py:4594: UserWarning: The operator 'aten::upsample_bicubic2d.out' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/mps/MPSFallback.mm:13.)
  return torch._C._nn.upsample_bicubic2d(

```